### PR TITLE
[Fixes #112367599] SurveyMonkey: Connection Time out errors when we do an OAuth

### DIFF
--- a/lib/omniauth/strategies/surveymonkey.rb
+++ b/lib/omniauth/strategies/surveymonkey.rb
@@ -7,13 +7,13 @@ module OmniAuth
       option :name, "surveymonkey"
 
       option :client_options, {
-        :site => "https://api.surveymonkey.com",
+        :site => "https://api.surveymonkey.net",
         :authorize_url => '/oauth/authorize',
         :token_url => '/oauth/token'
       }
 
       option :authorize_options, [:api_key]
-      
+
       def callback_phase
         options[:client_options][:token_url] = "/oauth/token?api_key=#{options[:api_key]}"
         super


### PR DESCRIPTION
When a user connects their account for the first time (or when they unlink and relink), we are getting a Connection timed out error during OAuth. 

Why? Due to some upcoming changes with the SurveyMonkey API, SurveyMonkey will be blocking access to api.surveymonkey.com, so we need to switch to api.surveymonkey.net instead. 
